### PR TITLE
Enforce resolved directory as workspace

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -2,8 +2,6 @@
 name: MegaLinter
 
 on:
-  push:
-
   pull_request:
     branches:
       - main

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
       `version`.
     required: false
     default: ""
+  workspace:
+    description: >
+      Directory to run the MegaLinter on. Defaults to the GitHub workspace.
+    required: false
+    default: ${{ github.workspace }}
 
 outputs:
   has_updated_sources:
@@ -61,5 +66,6 @@ runs:
         MLR_RELEASE: ${{ inputs.version }}
         MLR_FLAVOR: ${{ inputs.flavor }}
         MLR_REGISTRY: ${{ inputs.registry }}
+        MLR_PATH: ${{ inputs.workspace }}
       run: |
         ${{ github.action_path }}/mega-linter-runner.sh -v


### PR DESCRIPTION
Unless manually specified, this will automatically set the DEFAULT_WORKSPACE environment variable to point to the location of the resolved path provided at the command-line. When run directly, this is the current directory. When run from the GitHub action, this is the GitHub workspace.