### PR TITLE
Turn on -it automatically when run from terminal

### DIFF
--- a/mega-linter-runner.sh
+++ b/mega-linter-runner.sh
@@ -195,11 +195,15 @@ fi
 # Start building the Docker command that we will run
 WDIR=$(abspath "$MLR_PATH")
 set -- \
+  --init \
   --rm \
   -v "${MLR_SOCKET}:/var/run/docker.sock:rw" \
   -v "${WDIR}:${WDIR}:rw" \
   -w "$WDIR" \
   "$MLR_IMAGE"
+if [ -t 0 ]; then
+  set -- -it "$@"
+fi
 
 # Enforce environment variables passed through the command line.
 _workspace=0


### PR DESCRIPTION
Improve interaction with container through:

+ Automatically turning on "interactive mode", e.g. `-it` option, when run from a terminal
+ Wrap the entrypoint with an init capture that will pass down signals to the container's process tree.